### PR TITLE
fix: permission denied error from firestore emulator

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/spi/v1/GrpcFirestoreRpc.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/spi/v1/GrpcFirestoreRpc.java
@@ -92,7 +92,8 @@ public class GrpcFirestoreRpc implements FirestoreRpc {
 
         clientContext =
             ClientContext.newBuilder()
-                .setCredentials(options.getCredentials())
+                .setCredentials(
+                    options.getHost().contains("localhost") ? options.getCredentials() : null)
                 .setExecutor(executor)
                 .setTransportChannel(transportChannel)
                 .setDefaultCallContext(GrpcCallContext.of(managedChannel, CallOptions.DEFAULT))

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/spi/v1/GrpcFirestoreRpc.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/spi/v1/GrpcFirestoreRpc.java
@@ -89,9 +89,10 @@ public class GrpcFirestoreRpc implements FirestoreRpc {
                 .executor(executor)
                 .build();
         TransportChannel transportChannel = GrpcTransportChannel.create(managedChannel);
+
         clientContext =
             ClientContext.newBuilder()
-                .setCredentials(null)
+                .setCredentials(options.getCredentials())
                 .setExecutor(executor)
                 .setTransportChannel(transportChannel)
                 .setDefaultCallContext(GrpcCallContext.of(managedChannel, CallOptions.DEFAULT))


### PR DESCRIPTION
 `PERMISSION_DENIED: Metadata operations require admin authentication.`